### PR TITLE
Add green-themed calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# euquerocaucladora
+# Calculadora Verde
+
+Esta é uma calculadora simples inspirada na Calculadora do Windows, mas com tema verde. Basta abrir `index.html` em um navegador para usar.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calculadora Verde</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="calculator">
+    <input type="text" id="display" readonly>
+    <div class="buttons">
+      <button class="btn" data-action="clear">C</button>
+      <button class="btn" data-action="backspace">&larr;</button>
+      <button class="btn" data-value="/">/</button>
+      <button class="btn" data-value="*">*</button>
+      <button class="btn" data-value="7">7</button>
+      <button class="btn" data-value="8">8</button>
+      <button class="btn" data-value="9">9</button>
+      <button class="btn" data-value="-">-</button>
+      <button class="btn" data-value="4">4</button>
+      <button class="btn" data-value="5">5</button>
+      <button class="btn" data-value="6">6</button>
+      <button class="btn" data-value="+">+</button>
+      <button class="btn" data-value="1">1</button>
+      <button class="btn" data-value="2">2</button>
+      <button class="btn" data-value="3">3</button>
+      <button class="btn" data-action="equals" rowspan="2">=</button>
+      <button class="btn zero" data-value="0">0</button>
+      <button class="btn" data-value=".">.</button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,24 @@
+const display = document.getElementById('display');
+const buttons = document.querySelectorAll('.btn');
+
+buttons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const value = btn.dataset.value;
+    const action = btn.dataset.action;
+    if (value) {
+      display.value += value;
+    } else if (action) {
+      if (action === 'clear') {
+        display.value = '';
+      } else if (action === 'backspace') {
+        display.value = display.value.slice(0, -1);
+      } else if (action === 'equals') {
+        try {
+          display.value = eval(display.value).toString();
+        } catch (e) {
+          display.value = 'Erro';
+        }
+      }
+    }
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,55 @@
+body {
+  background-color: #e9ffe9;
+  font-family: Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.calculator {
+  background-color: #1f401f;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+#display {
+  width: 100%;
+  height: 40px;
+  margin-bottom: 10px;
+  font-size: 20px;
+  text-align: right;
+  padding-right: 10px;
+  border: none;
+  background-color: #e9ffe9;
+}
+
+.buttons {
+  display: grid;
+  grid-template-columns: repeat(4, 60px);
+  grid-gap: 10px;
+}
+
+.btn {
+  background-color: #4caf50;
+  border: none;
+  color: white;
+  padding: 15px;
+  font-size: 18px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background-color: #45a049;
+}
+
+.zero {
+  grid-column: span 2;
+}
+
+.btn[rowspan="2"] {
+  grid-row: span 2;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- implement a simple calculator styled in green
- document usage in README

## Testing
- `node -e "console.log(eval('1+2+3'));"`

------
https://chatgpt.com/codex/tasks/task_e_6850f15ea6c083338bc3d861a3ead2b2